### PR TITLE
V3 address verification improvements

### DIFF
--- a/lib/zwiebel.rb
+++ b/lib/zwiebel.rb
@@ -31,7 +31,7 @@ module Zwiebel
     #    - H is SHA3-256
     #    - CHECKSUM is truncated to two bytes before inserting it in onion_address
 
-    return false unless address.end_with?(".onion") && address.length == 62
+    return false unless address.is_a?(String) && address.end_with?(".onion") && address.length == 62
 
     decoded_address = Base32.decode(address.gsub(".onion", "").upcase)
     pubkey = decoded_address.byteslice(0, 32)

--- a/spec/zwiebel/zwiebel_spec.rb
+++ b/spec/zwiebel/zwiebel_spec.rb
@@ -4,15 +4,18 @@ require "tempfile"
 
 RSpec.describe "Zwiebel" do
   context "verify v3 onion address" do
-    it "valid" do
-      expect(Zwiebel.v3_address_valid?("qubesosfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion")).to be true
-      expect(Zwiebel.v3_address_valid?("gm64cjz7un7ucso4yegkssuqfzmg7ctn7mkb66c7l6sj7gzyo6syphid.onion")).to be true
+    context "valid" do
+      it { expect(Zwiebel.v3_address_valid?("qubesosfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion")).to be true }
+      it { expect(Zwiebel.v3_address_valid?("gm64cjz7un7ucso4yegkssuqfzmg7ctn7mkb66c7l6sj7gzyo6syphid.onion")).to be true }
     end
 
-    it "invalid" do
-      expect(Zwiebel.v3_address_valid?("invalid")).to be false
-      expect(Zwiebel.v3_address_valid?("gm64cjz7un7ucso4yegkssuqfzmg7ctn6mkb66c7l6sj7gzyo6syphid.onion")).to be false
-      expect(Zwiebel.v3_address_valid?("gm64cjz7un7ucso4yegkssuqfzmg7ssuqfzmg7ctn6mkb66c7l6sj7gzyo6syphid.onion")).to be false
+    context "invalid" do
+      it { expect(Zwiebel.v3_address_valid?("gm64cjz7un7ucso4yegkssuqfzmg7ctn6mkb66c7l6sj7gzyo6syphid.onion")).to be false }
+      it { expect(Zwiebel.v3_address_valid?("gm64cjz7un7ucso4yegkssuqfzmg7ssuqfzmg7ctn6mkb66c7l6sj7gzyo6syphid.onion")).to be false }
+      it { expect(Zwiebel.v3_address_valid?("invalid")).to be false }
+      it { expect(Zwiebel.v3_address_valid?(1)).to be false }
+      it { expect(Zwiebel.v3_address_valid?(nil)).to be false }
+      it { expect(Zwiebel.v3_address_valid?("")).to be false }
     end
   end
 


### PR DESCRIPTION
Add parameter `String` checks to the `v3_address_valid?` method.